### PR TITLE
Improved examples in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,76 @@ Usage: cmarks [OPTION]
 
 ### Examples
 
-Find the history index number for a recent command:
-`fc -l`
+1. Find the history index number for a recent command:
 
-Add a single command to cmarks (also works for delete/get/print):
-`cmarks -a <num>`
+   ```sh
+   % fc -l
+    2387  glow README.md
+    2388  podman machine start
+    2389  podman pull fedora
+    2390  podman run -it fedora bash
+    2391  podman machine stop
+   ```
 
-Add the previous command to cmarks:
-`cmarks -a -1`
+2. Add a command to cmarks:
 
-Add a range of commands to cmarks (also works for delete/get/print):
-`cmarks -a <num1>,<num2>`
+   ```sh
+   % cmarks -a 2388
+   % cmarks -l
+      1 2022-15-01 13:20  podman machine start
+   ```
+
+   You can also reference previous commands with negative numbers:
+
+   ```sh
+   % cmarks -a -1
+   % cmarks -l
+      1 2022-15-01 13:30  podman machine stop
+   ```
+
+   Or use a range to capture multiple commands:
+
+   ```sh
+   % cmarks -a 2388,2390
+   % cmarks -l
+      1 2022-15-01 13:20  podman machine start
+      2 2022-15-01 13:25  podman pull fedora
+      3 2022-15-01 13:30  podman run -it fedora bash
+   ```
+
+3. Print a bookmarked command:
+
+   ```sh
+   % cmarks -p 3
+   podman run -it fedora bash
+   ```
+
+4. Get a bookmarked command and append to history:
+
+   ```sh
+   % fc -l
+    2476  ansible-lint playbooks/site.yml
+    2477  ansible-playbook playbooks/site.yml
+   % cmarks -g 2
+   ```
+
+   Press `↑` to quickly access the command. You can also see the command in your history:
+
+   ```sh
+   % fc -l
+    2476  ansible-lint playbooks/site.yml
+    2477  ansible-playbook playbooks/site.yml
+    2478  podman pull fedora
+   ```
+
+5. Delete a bookmarked command:
+
+   ```sh
+   % cmarks -d 2
+   % cmarks -l
+      1 2022-15-01 13:20  podman machine start
+      2 2022-15-01 13:30  podman run -it fedora bash
+   ```
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Usage: cmarks [OPTION]
    % fc -l
     2476  ansible-lint playbooks/site.yml
     2477  ansible-playbook playbooks/site.yml
-    2478  podman pull fedora
+    2478  cmarks -g 2
+    2479  podman pull fedora
    ```
 
 5. Delete a bookmarked command:

--- a/cmarks.cfg
+++ b/cmarks.cfg
@@ -1,2 +1,0 @@
-cmarks_file="~/.cmarks"
-github_gist_id=


### PR DESCRIPTION
Examples in the `README` now better show how to use `cmarks`.